### PR TITLE
Fix mobile scroll lag by disabling parallax on mobile

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -208,6 +208,71 @@
     }
 }
 
+/* ============================================
+   MOBILE SCROLL PERFORMANCE
+   Disable jarallax parallax & skrollr on mobile.
+   Use simple static backgrounds instead of
+   JS-repositioned elements for smooth scrolling.
+   ============================================ */
+@media (max-width: 991px) {
+
+    /* --- Jarallax fallback ---
+       jarallax-img elements are hidden (JS won't reposition them).
+       Sections get a static CSS background from their data-bgimage. */
+    .jarallax > .jarallax-img {
+        display: none !important;
+    }
+
+    /* Hero uses <img class="jarallax-img"> instead of data-bgimage,
+       so we need a specific rule for that section */
+    #section-hero.jarallax {
+        background: url('../images/background/landscape.jpg') center/cover no-repeat;
+    }
+
+    #section-about.jarallax {
+        background: url('../images/background/stars.jpg') center/cover no-repeat;
+    }
+
+    #section-blog.jarallax {
+        background: url('../images/background/north.jpg') center/cover no-repeat;
+    }
+
+    /* Sections using data-bgimage (set via JS) — ensure cover */
+    .jarallax[data-bgimage] {
+        background-size: cover !important;
+        background-position: center !important;
+        background-repeat: no-repeat !important;
+    }
+
+    /* --- Disable skrollr scroll-driven transforms ---
+       Elements with data-bottom-top / data-top-bottom get
+       translateX/Y animations on scroll via skrollr. Kill them. */
+    [data-bottom-top],
+    [data-top-bottom] {
+        transform: none !important;
+        -webkit-transform: none !important;
+    }
+
+    /* --- GPU compositing for smooth native scroll --- */
+    section {
+        will-change: auto;
+        -webkit-transform: translateZ(0);
+        transform: translateZ(0);
+    }
+
+    /* Reduce WOW.js animation complexity on mobile */
+    .wow {
+        animation-duration: 0.4s !important;
+    }
+
+    /* Disable the fade-top / fade-bottom pseudo-element
+       gradient overlays if they use heavy compositing */
+    .fade-top::before,
+    .fade-bottom::after {
+        opacity: 0.5;
+    }
+}
+
 /* Print styles */
 @media print {
 

--- a/js/designesia.js
+++ b/js/designesia.js
@@ -1815,7 +1815,10 @@
         de_countdown();
         dropdown('#item_category');
         image_preview();
-        $(".jarallax").jarallax();
+        // Only init jarallax parallax on desktop — too heavy for mobile scroll perf
+        if (window.innerWidth > 991) {
+            $(".jarallax").jarallax();
+        }
         $(function () {
             $('.lazy').lazy();
         });
@@ -2280,11 +2283,13 @@
         load_owl();
         filter_gallery();
         window.dispatchEvent(new Event('resize'));
-        skrollr.init();
-
-        var s = skrollr.init();
-        if (s.isMobile()) {
-            s.destroy();
+        // Only init skrollr on desktop (>1024px) — scroll-driven transforms cause jank on mobile
+        if (window.innerWidth > 1024) {
+            skrollr.init({
+                smoothScrolling: true,
+                smoothScrollingDuration: 300,
+                forceHeight: false
+            });
         }
 
         $('.grid').isotope({


### PR DESCRIPTION
- Disable jarallax parallax initialization on screens <=991px

- Disable skrollr scroll-driven transforms on screens <=1024px

- Add CSS fallback backgrounds for jarallax sections on mobile

- Hide jarallax-img elements on mobile (not repositioned by JS)

- Kill data-bottom-top/data-top-bottom transform animations on mobile

- Add GPU compositing hints (translateZ) for smoother native scroll

- Reduce WOW.js animation duration on mobile for snappier feel

- Fix redundant double skrollr.init() call in designesia.js